### PR TITLE
Fix booking cutoff

### DIFF
--- a/ios/Rooms/Sources/RoomModels/RoomBooking.swift
+++ b/ios/Rooms/Sources/RoomModels/RoomBooking.swift
@@ -26,6 +26,12 @@ public struct RoomBooking: Equatable, Sendable, Hashable {
     name: "COMM2501 LAB",
     start: formatter.date(from: "2025-11-11T22:00:00.000Z")!)
 
+  public static let twoAMToThreePM = RoomBooking(
+    bookingType: "CLASS",
+    end: formatter.date(from: "2026-03-24T04:00:30.000Z")!,
+    name: "COMM2501 LAB",
+    start: formatter.date(from: "2026-03-23T15:00:30.000Z")!)
+
   public static let exampleTwo = RoomBooking(
     bookingType: "CLASS",
     end: formatter.date(from: "2025-11-12T01:00:00.000Z")!,

--- a/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
@@ -18,7 +18,7 @@ struct RoomBookingCardView: View {
     self.booking = booking
     start = Calendar.current.dateComponents([.hour, .minute], from: booking.start)
     end = Calendar.current.dateComponents([.hour, .minute], from: booking.end)
-    startMinutes = (start.hour ?? 0) * 60 + (start.minute ?? 0) - (60 * 8)
+    startMinutes = max((start.hour ?? 0) * 60 + (start.minute ?? 0), 9 * 60) - (60 * 9)
   }
 
   // MARK: Internal
@@ -66,7 +66,14 @@ struct RoomBookingCardView: View {
     let endTotalMinutes = endTimeHour * 60 + endTimeMinute
     let range = abs(endTotalMinutes - startTotalMinutes)
 
-    return CGFloat(range / 30)
+    // Remove extra time
+    let timeToRemove =
+      if startTimeHour < 9, endTimeHour > 9 {
+        9 * 60 - startTotalMinutes
+      } else {
+        0
+      }
+    return CGFloat((range - timeToRemove) / 30)
   }
 
   var time: (String, String) {

--- a/ios/Rooms/Sources/RoomViews/RoomBookingsListView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingsListView.swift
@@ -24,7 +24,7 @@ struct RoomBookingsListView: View {
 
   @Binding var dateSelect: Date
 
-  let hoursToDisplay: CGFloat = 24 - 8
+  let hoursToDisplay: CGFloat = 24 - 9
 
   var dateComponent: DateComponents {
     Calendar.current.dateComponents([.day, .month, .year, .hour, .minute], from: dateSelect)
@@ -49,7 +49,7 @@ struct RoomBookingsListView: View {
 
           // Background time grid
           VStack(spacing: 0) {
-            ForEach(8..<24, id: \.self) { hour in
+            ForEach(9..<24, id: \.self) { hour in
               BookingsLayoutView(hour: hour)
                 .id(hour)
             }


### PR DESCRIPTION
## What

Added minimum starting offset for booking view

## Why

Bookings made earlier than 9am would cut off at the top

## How

Just added a min check for starting and removed extra time for the frame

## Screenshot / Recording

Before:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/7189b238-a17d-480d-a61d-361f79e49ff0" />

After:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/19016927-d6b2-4853-8f07-3b0d44b43263" />