### PR TITLE
(FEAT): Image Cache

### DIFF
--- a/ios/Buildings/Sources/BuildingViews/BuildingImage.swift
+++ b/ios/Buildings/Sources/BuildingViews/BuildingImage.swift
@@ -5,10 +5,14 @@
 //  Created by Dicko Evaldo on 20/6/2025.
 //
 
+import CommonUI
 import SwiftUI
 
 public enum BuildingImage {
-  public static subscript(buildingID: String) -> Image {
-    Image(buildingID, bundle: .module)
+  public static subscript(buildingID: String, size: ImageSize = .medium) -> CachedImage {
+    CachedImage(
+      name: buildingID,
+      bundle: .module,
+      size: size)
   }
 }

--- a/ios/Buildings/Sources/BuildingViews/MapViews/SheetBuildingDetails.swift
+++ b/ios/Buildings/Sources/BuildingViews/MapViews/SheetBuildingDetails.swift
@@ -50,7 +50,6 @@ public struct SheetBuildingDetails: View {
   private var buildingImageSection: some View {
     if let buildingID = viewModel.selectedBuildingID {
       BuildingImage[buildingID]
-        .resizable()
         .aspectRatio(contentMode: .fill)
         .frame(maxWidth: .infinity, maxHeight: 150)
         .clipShape(RoundedRectangle(cornerRadius: 5))

--- a/ios/CommonUI/Sources/CommonUI/GenericCardView.swift
+++ b/ios/CommonUI/Sources/CommonUI/GenericCardView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 // MARK: - GenericCardView
 
-public struct GenericCardView<T: Equatable & Identifiable & Hashable & HasName & HasRating>: View {
+public struct GenericCardView<T: Equatable & Identifiable & Hashable & HasName & HasRating, ImageContent: View>: View {
 
   // MARK: Lifecycle
 
@@ -22,7 +22,7 @@ public struct GenericCardView<T: Equatable & Identifiable & Hashable & HasName &
     item: T,
     items: [T],
     isLoading: Bool,
-    imageProvider: @escaping (T.ID) -> Image)
+    imageProvider: @escaping (T.ID) -> ImageContent)
   {
     _path = path
     _cardWidth = cardWidth
@@ -40,7 +40,6 @@ public struct GenericCardView<T: Equatable & Identifiable & Hashable & HasName &
     } label: {
       VStack(spacing: 0) {
         imageProvider(item.id)
-          .resizable()
           .scaledToFill()
           .frame(width: cardWidth, height: 116)
           .clipped()
@@ -76,7 +75,7 @@ public struct GenericCardView<T: Equatable & Identifiable & Hashable & HasName &
 
   let item: T
   let items: [T]
-  let imageProvider: (T.ID) -> Image
+  let imageProvider: (T.ID) -> ImageContent
   let isLoading: Bool
 
   var index: Int {
@@ -85,14 +84,14 @@ public struct GenericCardView<T: Equatable & Identifiable & Hashable & HasName &
 
 }
 
-extension GenericCardView where T == Building {
+extension GenericCardView where T == Building, ImageContent == CachedImage {
   public init(
     path: Binding<NavigationPath>,
     cardWidth: Binding<CGFloat?>,
     building: Building,
     buildings: [Building],
     isLoading: Bool,
-    imageProvider: @escaping (Building.ID) -> Image)
+    imageProvider: @escaping (Building.ID) -> CachedImage)
   {
     _path = path
     _cardWidth = cardWidth
@@ -103,14 +102,14 @@ extension GenericCardView where T == Building {
   }
 }
 
-extension GenericCardView where T == Room {
+extension GenericCardView where T == Room, ImageContent == CachedImage {
   public init(
     path: Binding<NavigationPath>,
     cardWidth: Binding<CGFloat?>,
     room: Room,
     rooms: [Room],
     isLoading: Bool,
-    imageProvider: @escaping (Room.ID) -> Image)
+    imageProvider: @escaping (Room.ID) -> CachedImage)
   {
     _path = path
     _cardWidth = cardWidth
@@ -139,7 +138,7 @@ struct CardPreviewWrapper: View {
           rooms: rooms,
           isLoading: true,
           imageProvider: { roomID in
-            Image(roomID, bundle: .module)
+            CachedImage(name: roomID, bundle: .module)
           })
       }
     }

--- a/ios/CommonUI/Sources/CommonUI/GenericListRowView.swift
+++ b/ios/CommonUI/Sources/CommonUI/GenericListRowView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 // MARK: - GenericListRowView
 
-public struct GenericListRowView<T: Equatable & Identifiable & Hashable & HasName & HasRating>: View {
+public struct GenericListRowView<T: Equatable & Identifiable & Hashable & HasName & HasRating, ImageContent: View>: View {
 
   // MARK: Lifecycle
 
@@ -22,7 +22,7 @@ public struct GenericListRowView<T: Equatable & Identifiable & Hashable & HasNam
     item: T,
     items: [T],
     isLoading: Bool,
-    imageProvider: @escaping (T.ID) -> Image)
+    imageProvider: @escaping (T.ID) -> ImageContent)
   {
     _path = path
     _rowHeight = rowHeight
@@ -40,7 +40,6 @@ public struct GenericListRowView<T: Equatable & Identifiable & Hashable & HasNam
     } label: {
       HStack(spacing: 0) {
         imageProvider(item.id)
-          .resizable()
           .aspectRatio(contentMode: .fill)
           .frame(width: (rowHeight ?? 0) + 40, height: 60)
           .clipShape(RoundedRectangle(cornerRadius: 5))
@@ -82,7 +81,7 @@ public struct GenericListRowView<T: Equatable & Identifiable & Hashable & HasNam
   let item: T
   let items: [T]
   let isLoading: Bool
-  let imageProvider: (T.ID) -> Image
+  let imageProvider: (T.ID) -> ImageContent
 
   var cornerRadii: RectangleCornerRadii {
     RectangleCornerRadii(
@@ -103,14 +102,14 @@ public struct GenericListRowView<T: Equatable & Identifiable & Hashable & HasNam
 }
 
 /// Convenience extensions
-extension GenericListRowView where T == Building {
+extension GenericListRowView where T == Building, ImageContent == CachedImage {
   public init(
     path: Binding<NavigationPath>,
     rowHeight: Binding<CGFloat?>,
     building: Building,
     buildings: [Building],
     isLoading: Bool,
-    imageProvider: @escaping (Building.ID) -> Image)
+    imageProvider: @escaping (Building.ID) -> CachedImage)
   {
     _path = path
     _rowHeight = rowHeight
@@ -121,14 +120,14 @@ extension GenericListRowView where T == Building {
   }
 }
 
-extension GenericListRowView where T == Room {
+extension GenericListRowView where T == Room, ImageContent == CachedImage {
   public init(
     path: Binding<NavigationPath>,
     rowHeight: Binding<CGFloat?>,
     room: Room,
     rooms: [Room],
     isLoading: Bool,
-    imageProvider: @escaping (Room.ID) -> Image)
+    imageProvider: @escaping (Room.ID) -> CachedImage)
   {
     _path = path
     _rowHeight = rowHeight
@@ -157,7 +156,7 @@ struct PreviewWrapper: View {
           rooms: rooms,
           isLoading: false,
           imageProvider: { roomID in
-            Image(roomID, bundle: .module)
+            CachedImage(name: roomID, bundle: .module)
           })
       }
     }

--- a/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
@@ -8,21 +8,21 @@ public struct CacheConfig {
   // MARK: Lifecycle
 
   public init(
-    nsCacheCountLimit: Int = defaultNSCacheCountLimit,
-    nsCacheTotalCostLimit: Int = defaultNSCacheTotalCostLimit)
+    maxItemCount: Int = defaultMaxItemCount,
+    maxByteCount: Int = defaultMaxByteCount)
   {
-    self.nsCacheCountLimit = nsCacheCountLimit
-    self.nsCacheTotalCostLimit = nsCacheTotalCostLimit
+    self.maxItemCount = maxItemCount
+    self.maxByteCount = maxByteCount
   }
 
   // MARK: Public
 
   public static let `default` = CacheConfig()
 
-  public static let defaultNSCacheCountLimit = 50
-  public static let defaultNSCacheTotalCostLimit = 50 * 1024 * 1024 // 50 MB
+  public static let defaultMaxItemCount = 50
+  public static let defaultMaxByteCount = 50 * 1024 * 1024 // 50 MB
 
-  public let nsCacheCountLimit: Int
-  public let nsCacheTotalCostLimit: Int
+  public let maxItemCount: Int
+  public let maxByteCount: Int
 
 }

--- a/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
@@ -19,11 +19,10 @@ public struct CacheConfig {
 
   public static let `default` = CacheConfig()
 
+  public static let defaultNSCacheCountLimit = 50
+  public static let defaultNSCacheTotalCostLimit = 50 * 1024 * 1024 // 50 MB
+
   public let nsCacheCountLimit: Int
   public let nsCacheTotalCostLimit: Int
 
-  // MARK: Private
-
-  public static let defaultNSCacheCountLimit = 50
-  public static let defaultNSCacheTotalCostLimit = 50 * 1024 * 1024 // 50 MB
 }

--- a/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
@@ -5,13 +5,23 @@
 
 public struct CacheConfig {
 
-  public let countLimit: Int
-  public let totalCostLimit: Int
+  // MARK: Public
 
-  public init(countLimit: Int = 50, totalCostLimit: Int = 50 * 1024 * 1024) {
-    self.countLimit = countLimit
-    self.totalCostLimit = totalCostLimit
+  public let nsCacheCountLimit: Int
+  public let nsCacheTotalCostLimit: Int
+
+  public init(
+    nsCacheCountLimit: Int = defaultNSCacheCountLimit,
+    nsCacheTotalCostLimit: Int = defaultNSCacheTotalCostLimit)
+  {
+    self.nsCacheCountLimit = nsCacheCountLimit
+    self.nsCacheTotalCostLimit = nsCacheTotalCostLimit
   }
 
   public static let `default` = CacheConfig()
+
+  // MARK: Private
+
+  private static let defaultNSCacheCountLimit = 50
+  private static let defaultNSCacheTotalCostLimit = 50 * 1024 * 1024 // 50 MB
 }

--- a/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
@@ -24,6 +24,6 @@ public struct CacheConfig {
 
   // MARK: Private
 
-  private static let defaultNSCacheCountLimit = 50
-  private static let defaultNSCacheTotalCostLimit = 50 * 1024 * 1024 // 50 MB
+  public static let defaultNSCacheCountLimit = 50
+  public static let defaultNSCacheTotalCostLimit = 50 * 1024 * 1024 // 50 MB
 }

--- a/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
@@ -1,0 +1,17 @@
+//
+//  CacheConfig.swift
+//  CommonUI
+//
+
+public struct CacheConfig {
+
+  public let countLimit: Int
+  public let totalCostLimit: Int
+
+  public init(countLimit: Int = 50, totalCostLimit: Int = 50 * 1024 * 1024) {
+    self.countLimit = countLimit
+    self.totalCostLimit = totalCostLimit
+  }
+
+  public static let `default` = CacheConfig()
+}

--- a/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CacheConfig.swift
@@ -5,10 +5,7 @@
 
 public struct CacheConfig {
 
-  // MARK: Public
-
-  public let nsCacheCountLimit: Int
-  public let nsCacheTotalCostLimit: Int
+  // MARK: Lifecycle
 
   public init(
     nsCacheCountLimit: Int = defaultNSCacheCountLimit,
@@ -18,7 +15,12 @@ public struct CacheConfig {
     self.nsCacheTotalCostLimit = nsCacheTotalCostLimit
   }
 
+  // MARK: Public
+
   public static let `default` = CacheConfig()
+
+  public let nsCacheCountLimit: Int
+  public let nsCacheTotalCostLimit: Int
 
   // MARK: Private
 

--- a/ios/CommonUI/Sources/CommonUI/Image/CachedImage.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/CachedImage.swift
@@ -1,0 +1,48 @@
+//
+//  CachedImage.swift
+//  CommonUI
+//
+
+import SwiftUI
+
+public struct CachedImage: View {
+
+  // MARK: Lifecycle
+
+  public init(
+    name: String,
+    bundle: Bundle,
+    size: ImageSize = .medium,
+    fallbackName: String? = nil,
+    fallbackBundle: Bundle? = nil)
+  {
+    self.name = name
+    self.bundle = bundle
+    self.size = size
+    self.fallbackName = fallbackName
+    self.fallbackBundle = fallbackBundle ?? bundle
+  }
+
+  // MARK: Public
+
+  public var body: some View {
+    let resolved = ImageCache.shared.image(named: name, in: bundle, size: size)
+      ?? fallbackName.flatMap { ImageCache.shared.image(named: $0, in: fallbackBundle, size: size) }
+
+    if let resolved {
+      Image(uiImage: resolved)
+        .resizable()
+    } else {
+      Rectangle()
+        .fill(.gray.opacity(0.15))
+    }
+  }
+
+  // MARK: Private
+
+  private let name: String
+  private let bundle: Bundle
+  private let size: ImageSize
+  private let fallbackName: String?
+  private let fallbackBundle: Bundle
+}

--- a/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
@@ -1,0 +1,117 @@
+//
+//  ImageCache.swift
+//  CommonUI
+//
+
+import UIKit
+
+// MARK: - ImageCache
+
+/// A shared image cache that stores downsampled thumbnails in an `NSCache`.
+///
+/// ## Why this exists
+///
+/// `UIImage(named:)` loads the full-resolution image and caches it in a
+/// system cache that doesn't release easily. A 2000x1500 photo decompresses
+/// into ~12 MB of bitmap memory. With ~270 bundled photos, scrolling through
+/// lists can balloon memory quickly.
+///
+/// `ImageCache` solves this by:
+/// 1. Downsampling to the display size via `preparingThumbnail(of:)` (~480 KB at `.medium`)
+/// 2. Storing the small thumbnail in an `NSCache` with configurable limits
+///
+/// ## Architecture
+///
+///     View layer (CachedImage)
+///         |
+///         +-- body: sync lookup via image(named:in:size:)
+///                   -> cache hit: instant return from NSCache
+///                   -> cache miss: UIImage(named:) + preparingThumbnail(of:)
+///                      -> store in NSCache with byte cost
+///                      -> return thumbnail
+///
+/// ## Cache key format
+///
+/// Keys are `"<imageName>-<pixelSize>"` (e.g. `"K-J17-201-400"`), so the same
+/// image at different sizes gets separate cache entries without collisions.
+///
+/// ## Memory budget
+///
+/// Default limits via `CacheConfig.default`: 50 items / 50 MB.
+/// Approximate per-thumbnail costs:
+/// - `.small` (200px):  ~120 KB
+/// - `.medium` (400px): ~480 KB
+/// - `.large` (1000px): ~3 MB
+///
+/// 50 MB holds ~100 medium thumbnails — enough to scroll through the full
+/// buildings list AND a building's room list without evictions. `NSCache`
+/// also purges automatically under system memory pressure.
+public final class ImageCache {
+
+  /// Shared singleton using `CacheConfig.default` limits (50 items / 50 MB).
+  public static let shared = ImageCache()
+
+  private let cache = NSCache<NSString, UIImage>()
+
+  /// Creates a cache with the given configuration.
+  ///
+  /// - Parameter config: Cache limits. Defaults to `CacheConfig.default`.
+  init(config: CacheConfig = .default) {
+    cache.countLimit = config.countLimit
+    cache.totalCostLimit = config.totalCostLimit
+  }
+
+  /// Loads an image from the asset catalog, downsamples it, and caches the result.
+  ///
+  /// On cache hit, returns the cached thumbnail immediately.
+  /// On cache miss, loads via `UIImage(named:)`, downsamples with
+  /// `preparingThumbnail(of:)`, stores the result, and returns it.
+  /// Falls back to the original image if thumbnail creation fails.
+  ///
+  /// - Parameters:
+  ///   - name: The asset name in the catalog (e.g. `"K-J17-201"`).
+  ///   - bundle: The resource bundle containing the asset catalog (e.g. `.module`).
+  ///   - size: The target `ImageSize`. Defaults to `.medium` (400px).
+  /// - Returns: A downsampled `UIImage`, or `nil` if the asset wasn't found.
+  public func image(
+    named name: String,
+    in bundle: Bundle,
+    size: ImageSize = .medium)
+    -> UIImage?
+  {
+    let maxPixelSize = size.rawValue
+    let key = "\(name)-\(Int(maxPixelSize))" as NSString
+
+    if let cached = cache.object(forKey: key) {
+      return cached
+    }
+
+    guard let original = UIImage(named: name, in: bundle, with: nil) else {
+      return nil
+    }
+
+    let aspectRatio = original.size.width / original.size.height
+    let thumbnailSize: CGSize = if aspectRatio > 1 {
+      CGSize(width: maxPixelSize, height: maxPixelSize / aspectRatio)
+    } else {
+      CGSize(width: maxPixelSize * aspectRatio, height: maxPixelSize)
+    }
+
+    guard let thumbnail = original.preparingThumbnail(of: thumbnailSize) else {
+      return original
+    }
+
+    let cost = thumbnail.cgImage.map { $0.bytesPerRow * $0.height } ?? 0
+    cache.setObject(thumbnail, forKey: key, cost: cost)
+
+    return thumbnail
+  }
+
+  /// Removes all cached thumbnails.
+  ///
+  /// Useful for debugging or a "clear cache" setting. Under normal operation,
+  /// `NSCache` handles eviction automatically under memory pressure.
+  public func clearCache() {
+    cache.removeAllObjects()
+  }
+}

--- a/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
@@ -38,7 +38,8 @@ import UIKit
 /// ## Memory budget
 ///
 /// Default limits via `CacheConfig.default`: 50 items / 50 MB.
-/// Approximate per-thumbnail costs:
+/// Approximate per-thumbnail costs (uncompressed bitmap: width × height × 4 bytes/pixel,
+/// independent of source format — JPEG, HEIC, etc. decompress to the same bitmap size):
 /// - `.small` (200px):  ~120 KB
 /// - `.medium` (400px): ~480 KB
 /// - `.large` (1000px): ~3 MB
@@ -54,8 +55,8 @@ public final class ImageCache {
   ///
   /// - Parameter config: Cache limits. Defaults to `CacheConfig.default`.
   init(config: CacheConfig = .default) {
-    cache.countLimit = config.countLimit
-    cache.totalCostLimit = config.totalCostLimit
+    cache.countLimit = config.nsCacheCountLimit
+    cache.totalCostLimit = config.nsCacheTotalCostLimit
   }
 
   // MARK: Public

--- a/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
@@ -55,8 +55,8 @@ public final class ImageCache {
   ///
   /// - Parameter config: Cache limits. Defaults to `CacheConfig.default`.
   init(config: CacheConfig = .default) {
-    cache.countLimit = config.nsCacheCountLimit
-    cache.totalCostLimit = config.nsCacheTotalCostLimit
+    cache.countLimit = config.maxItemCount
+    cache.totalCostLimit = config.maxByteCount
   }
 
   // MARK: Public

--- a/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/ImageCache.swift
@@ -48,10 +48,7 @@ import UIKit
 /// also purges automatically under system memory pressure.
 public final class ImageCache {
 
-  /// Shared singleton using `CacheConfig.default` limits (50 items / 50 MB).
-  public static let shared = ImageCache()
-
-  private let cache = NSCache<NSString, UIImage>()
+  // MARK: Lifecycle
 
   /// Creates a cache with the given configuration.
   ///
@@ -60,6 +57,11 @@ public final class ImageCache {
     cache.countLimit = config.countLimit
     cache.totalCostLimit = config.totalCostLimit
   }
+
+  // MARK: Public
+
+  /// Shared singleton using `CacheConfig.default` limits (50 items / 50 MB).
+  public static let shared = ImageCache()
 
   /// Loads an image from the asset catalog, downsamples it, and caches the result.
   ///
@@ -91,11 +93,12 @@ public final class ImageCache {
     }
 
     let aspectRatio = original.size.width / original.size.height
-    let thumbnailSize: CGSize = if aspectRatio > 1 {
-      CGSize(width: maxPixelSize, height: maxPixelSize / aspectRatio)
-    } else {
-      CGSize(width: maxPixelSize * aspectRatio, height: maxPixelSize)
-    }
+    let thumbnailSize: CGSize =
+      if aspectRatio > 1 {
+        CGSize(width: maxPixelSize, height: maxPixelSize / aspectRatio)
+      } else {
+        CGSize(width: maxPixelSize * aspectRatio, height: maxPixelSize)
+      }
 
     guard let thumbnail = original.preparingThumbnail(of: thumbnailSize) else {
       return original
@@ -114,4 +117,9 @@ public final class ImageCache {
   public func clearCache() {
     cache.removeAllObjects()
   }
+
+  // MARK: Private
+
+  private let cache = NSCache<NSString, UIImage>()
+
 }

--- a/ios/CommonUI/Sources/CommonUI/Image/ImageSize.swift
+++ b/ios/CommonUI/Sources/CommonUI/Image/ImageSize.swift
@@ -1,0 +1,11 @@
+//
+//  ImageSize.swift
+//  CommonUI
+//
+import Foundation
+
+public enum ImageSize: CGFloat {
+  case small = 200
+  case medium = 400
+  case large = 1000
+}

--- a/ios/Rooms/Sources/RoomViews/RoomDetailsView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomDetailsView.swift
@@ -25,8 +25,7 @@ public struct RoomDetailsView: View {
 
   public var body: some View {
     VStack(spacing: 0) {
-      RoomImage[room.id]
-        .resizable()
+      RoomImage[room.id, .large]
         .scaledToFill()
         .frame(height: screenHeight * 0.4)
         .clipped()

--- a/ios/Rooms/Sources/RoomViews/RoomImage.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomImage.swift
@@ -5,14 +5,15 @@
 //  Created by Yanlin on 23/6/2025.
 //
 
+import CommonUI
 import SwiftUI
 
 public enum RoomImage {
-  public static subscript(roomID: String) -> Image {
-    if let uiImage = UIImage(named: roomID, in: .module, with: nil) {
-      Image(uiImage: uiImage)
-    } else {
-      Image("default", bundle: .module)
-    }
+  public static subscript(roomID: String, size: ImageSize = .medium) -> CachedImage {
+    CachedImage(
+      name: roomID,
+      bundle: .module,
+      size: size,
+      fallbackName: "default")
   }
 }

--- a/ios/Rooms/Sources/RoomViews/RoomsListView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomsListView.swift
@@ -20,7 +20,7 @@ public struct RoomsListView: View {
     roomViewModel: RoomViewModel,
     building: Building,
     path: Binding<NavigationPath>,
-    imageProvider: @escaping (String) -> Image)
+    imageProvider: @escaping (String) -> CachedImage)
   {
     self.roomViewModel = roomViewModel
     self.building = building
@@ -35,7 +35,6 @@ public struct RoomsListView: View {
 
     return List {
       imageProvider(building.id)
-        .resizable()
         .frame(height: screenHeight / 4)
         .clipShape(RoundedRectangle(cornerRadius: 15))
         .listRowInsets(EdgeInsets()) // remove default list padding
@@ -84,7 +83,7 @@ public struct RoomsListView: View {
 
   let screenHeight = UIScreen.main.bounds.height
 
-  let imageProvider: (String) -> Image
+  let imageProvider: (String) -> CachedImage
 
   // MARK: Private
 


### PR DESCRIPTION
## What

- new image cache system to reduce runtime memory use.

## Why

- we were exploding user's memory usage by having near 1GB of runtime memory usage

## How

- Claude Code 🥇 
- downsample image so we don't use full resolution of the image
- used NSCache to cache the image max 50mb configurable
- considered using Nuke / Kingfisher but overkill for our project ( fetching from bundle not the internet) 


# Result

- in the room page we can see a reduction from 980mb to 160mb so thats a 6X memory usage reduction 🚀 

## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [X] Code comments where needed
- [X] No new warnings

## Manual tests:

- [X] Big iPhone (iPhone 17 Pro Max)
- [ ] Small iPhone (iPhone SE)

## Screenshot / Recording

N/A