### PR TITLE
fix: made rounded corners flat when booking starts earlier than 9 am

### DIFF
--- a/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
@@ -22,14 +22,32 @@ struct RoomBookingCardView: View {
   }
 
   // MARK: Internal
+    
+    var topRadius: CGFloat {
+        if (start.hour ?? 0) < 9 {
+            0
+        } else if isSmallBooking {
+            10
+        } else {
+            15
+        }
+    }
+    
+    var bottomRadius: CGFloat {
+        if isSmallBooking {
+            10
+        } else {
+            15
+        }
+    }
 
   var body: some View {
     ZStack(alignment: .topLeading) {
       UnevenRoundedRectangle(
-        topLeadingRadius: isSmallBooking ? 10 : 15,
-        bottomLeadingRadius: isSmallBooking ? 10 : 15,
-        bottomTrailingRadius: isSmallBooking ? 10 : 15,
-        topTrailingRadius: isSmallBooking ? 10 : 15)
+        topLeadingRadius: topRadius,
+        bottomLeadingRadius: bottomRadius,
+        bottomTrailingRadius: bottomRadius,
+        topTrailingRadius: topRadius)
         .fill(theme.accent.primary)
 
       VStack(alignment: .leading, spacing: 2 * (isSmallBooking ? 0.5 : numberTimeSlots)) {
@@ -55,7 +73,7 @@ struct RoomBookingCardView: View {
       x: 0,
       y: CGFloat(startMinutes) * (40 / 60) + 2)
   }
-
+    
   var numberTimeSlots: CGFloat {
     let startTimeMinute = start.minute ?? 0
     let startTimeHour = start.hour ?? 0

--- a/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
@@ -22,24 +22,24 @@ struct RoomBookingCardView: View {
   }
 
   // MARK: Internal
-    
-    var topRadius: CGFloat {
-        if (start.hour ?? 0) < 9 {
-            0
-        } else if isSmallBooking {
-            10
-        } else {
-            15
-        }
+
+  var topRadius: CGFloat {
+    if (start.hour ?? 0) < 9 {
+      0
+    } else if isSmallBooking {
+      10
+    } else {
+      15
     }
-    
-    var bottomRadius: CGFloat {
-        if isSmallBooking {
-            10
-        } else {
-            15
-        }
+  }
+
+  var bottomRadius: CGFloat {
+    if isSmallBooking {
+      10
+    } else {
+      15
     }
+  }
 
   var body: some View {
     ZStack(alignment: .topLeading) {
@@ -73,7 +73,7 @@ struct RoomBookingCardView: View {
       x: 0,
       y: CGFloat(startMinutes) * (40 / 60) + 2)
   }
-    
+
   var numberTimeSlots: CGFloat {
     let startTimeMinute = start.minute ?? 0
     let startTimeHour = start.hour ?? 0


### PR DESCRIPTION
## What

Made top corners flat when booking starts earlier than 9am

## Why

More visual clarity that the booking doesn't start at 9am

## How

Added a check when adding corner radiuses

## Screenshot / Recording

Before:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/1314f0b0-8871-4f37-9c9e-f050c62331c4" />

After:
<img height="500" alt="simulator_screenshot_9E7623BC-28DF-4A55-B095-14ABAB59A00A" src="https://github.com/user-attachments/assets/656c721d-4d3a-46f7-b9cd-a0aeec348c65" />
