### PR TITLE
fix: Removed map controls from MapTabView

### DIFF
--- a/ios/Buildings/Sources/BuildingViews/MapViews/MapTabView.swift
+++ b/ios/Buildings/Sources/BuildingViews/MapViews/MapTabView.swift
@@ -73,6 +73,9 @@ public struct MapTabView: View {
         mapViewModel.updateMapHeading(context.camera.heading)
       }
       .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
+      .mapControls {
+        // Specifying no map controls removes the compass
+      }
       .bottomSheet(
         bottomSheetPosition: $mapViewModel.bottomSheetPosition,
         switchablePositions: [SheetPosition.medium.bottomSheetPosition, SheetPosition.short.bottomSheetPosition])


### PR DESCRIPTION
Using the .mapControls(_:) view modifier with no views removes controls from the map, including the compass. We should find a solution to adding search to the Map that doesn't obstruct map controls in the future.

## What

Removed the compass from the map

