### PR TITLE
Fix Booking Cards To Be Responsive

### DIFF
--- a/ios/Rooms/Sources/RoomViews/BookingsLayoutView.swift
+++ b/ios/Rooms/Sources/RoomViews/BookingsLayoutView.swift
@@ -15,11 +15,12 @@ struct BookingsLayoutView: View {
   var hour: Int
 
   let borderColor = Color.gray.opacity(0.3)
+  let slotHeight: CGFloat = 60
 
   var body: some View {
     HStack {
       Text(formatHour(hour))
-        .frame(width: 50, height: 40, alignment: .topTrailing)
+        .frame(width: 50, height: slotHeight, alignment: .topTrailing)
         .foregroundStyle(theme.accent.primary)
         .overlay(
           VStack(spacing: 0) {
@@ -35,11 +36,11 @@ struct BookingsLayoutView: View {
       VStack(spacing: 0) {
         Rectangle()
           .strokeBorder(borderColor, lineWidth: 1)
-          .frame(height: 20)
+          .frame(height: slotHeight / 2)
 
         Rectangle()
           .fill(.clear)
-          .frame(height: 20)
+          .frame(height: slotHeight / 2)
           .overlay(alignment: .leading) {
             Rectangle()
               .frame(width: 1)

--- a/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
@@ -24,20 +24,20 @@ struct RoomBookingCardView: View {
   // MARK: Internal
 
   var topRadius: CGFloat {
-    switch (bookingSize) {
-      case .small:
-          return 8
-      case .medium:
-        return 10
+    switch bookingSize {
+    case .small:
+      8
+    case .medium:
+      10
     }
   }
 
   var bottomRadius: CGFloat {
-    switch (bookingSize) {
-      case .small:
-          return 8
-      case .medium:
-        return 10
+    switch bookingSize {
+    case .small:
+      8
+    case .medium:
+      10
     }
   }
 
@@ -52,17 +52,17 @@ struct RoomBookingCardView: View {
 
       VStack(alignment: .leading, spacing: 3 * (bookingSize == .small ? 1 : 2)) {
         Text("\(time.0) - \(time.1)")
-          .font(.system(size: (bookingSize == .small ? 8 : 12), weight: .medium))
+          .font(.system(size: bookingSize == .small ? 8 : 12, weight: .medium))
 
         Text("\(booking.name)")
-          .font(.system(size: (bookingSize == .small ? 14 : 20), weight: .medium))
+          .font(.system(size: bookingSize == .small ? 14 : 20, weight: .medium))
       }
-      .padding(.vertical, (bookingSize == .small ? 1 : 4))
+      .padding(.vertical, bookingSize == .small ? 1 : 4)
       .padding(.horizontal, 10)
       .bold()
       .foregroundStyle(.white)
     }
-    .frame(height: ((30 * numberTimeSlots) - 4))
+    .frame(height: (30 * numberTimeSlots) - 4)
     .offset(
       x: 0,
       y: CGFloat(startMinutes) + 2)
@@ -99,6 +99,10 @@ struct RoomBookingCardView: View {
 
   // MARK: Private
 
+  private enum BookingSize {
+    case small, medium
+  }
+
   @Environment(Theme.self) private var theme
 
   private var room: Room
@@ -106,16 +110,12 @@ struct RoomBookingCardView: View {
   private var start: DateComponents
   private var end: DateComponents
   private let startMinutes: Int
-  
-  private enum BookingSize{
-      case small, medium
-  }
 
   private var bookingSize: BookingSize {
-    if (numberTimeSlots == 1) {
-      return .small
+    if numberTimeSlots == 1 {
+      .small
     } else {
-      return .medium
+      .medium
     }
   }
 

--- a/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingCardView.swift
@@ -24,20 +24,20 @@ struct RoomBookingCardView: View {
   // MARK: Internal
 
   var topRadius: CGFloat {
-    if (start.hour ?? 0) < 9 {
-      0
-    } else if isSmallBooking {
-      10
-    } else {
-      15
+    switch (bookingSize) {
+      case .small:
+          return 8
+      case .medium:
+        return 10
     }
   }
 
   var bottomRadius: CGFloat {
-    if isSmallBooking {
-      10
-    } else {
-      15
+    switch (bookingSize) {
+      case .small:
+          return 8
+      case .medium:
+        return 10
     }
   }
 
@@ -50,28 +50,22 @@ struct RoomBookingCardView: View {
         topTrailingRadius: topRadius)
         .fill(theme.accent.primary)
 
-      VStack(alignment: .leading, spacing: 2 * (isSmallBooking ? 0.5 : numberTimeSlots)) {
+      VStack(alignment: .leading, spacing: 3 * (bookingSize == .small ? 1 : 2)) {
         Text("\(time.0) - \(time.1)")
-          .font(
-            isSmallBooking
-              ? .system(size: 10, weight: .medium)
-              : .system(size: 12, weight: .medium))
+          .font(.system(size: (bookingSize == .small ? 8 : 12), weight: .medium))
 
         Text("\(booking.name)")
-          .font(
-            isSmallBooking
-              ? .system(size: 18, weight: .medium)
-              : .system(size: 20, weight: .medium))
+          .font(.system(size: (bookingSize == .small ? 14 : 20), weight: .medium))
       }
-      .padding(isSmallBooking ? 2 : 10)
-      .padding(.horizontal, isSmallBooking ? 10 : 0)
+      .padding(.vertical, (bookingSize == .small ? 1 : 4))
+      .padding(.horizontal, 10)
       .bold()
       .foregroundStyle(.white)
     }
-    .frame(height: (20 * numberTimeSlots) - 4)
+    .frame(height: ((30 * numberTimeSlots) - 4))
     .offset(
       x: 0,
-      y: CGFloat(startMinutes) * (40 / 60) + 2)
+      y: CGFloat(startMinutes) + 2)
   }
 
   var numberTimeSlots: CGFloat {
@@ -112,9 +106,17 @@ struct RoomBookingCardView: View {
   private var start: DateComponents
   private var end: DateComponents
   private let startMinutes: Int
+  
+  private enum BookingSize{
+      case small, medium
+  }
 
-  private var isSmallBooking: Bool {
-    numberTimeSlots < 4
+  private var bookingSize: BookingSize {
+    if (numberTimeSlots == 1) {
+      return .small
+    } else {
+      return .medium
+    }
   }
 
   private func formatHour(_ hour: Int, _ minute: Int) -> String {

--- a/ios/Rooms/Sources/RoomViews/RoomBookingsListView.swift
+++ b/ios/Rooms/Sources/RoomViews/RoomBookingsListView.swift
@@ -25,6 +25,7 @@ struct RoomBookingsListView: View {
   @Binding var dateSelect: Date
 
   let hoursToDisplay: CGFloat = 24 - 9
+  let slotHeight: CGFloat = 60
 
   var dateComponent: DateComponents {
     Calendar.current.dateComponents([.day, .month, .year, .hour, .minute], from: dateSelect)
@@ -44,7 +45,7 @@ struct RoomBookingsListView: View {
           if roomViewModel.getBookingsIsLoading {
             RoundedRectangle(cornerRadius: 12)
               .fill(Color.gray.opacity(0.3))
-              .frame(height: 24 * 40)
+              .frame(height: 24 * slotHeight)
           }
 
           // Background time grid
@@ -65,9 +66,9 @@ struct RoomBookingsListView: View {
               .padding(.trailing, 10)
           }
         }
-        .frame(height: hoursToDisplay * 40)
+        .frame(height: hoursToDisplay * slotHeight)
       }
-      .frame(height: hoursToDisplay * 40)
+      .frame(height: hoursToDisplay * slotHeight)
       .clipShape(RoundedRectangle(cornerRadius: 12))
       .onAppear {
         let currentHour = max(dateComponent.hour ?? 0, 9)


### PR DESCRIPTION
## What

Enlargened the booking slot height in the room booking list and tweaked booking card to be responsive to their size.

## Why

When opening the room booking list in a room, any 30-minute bookings were not displayed correctly and overflowed. Additional space was required for the content to display properly.

## How

Defined a new constant slotHeight in BookingsList and BookingsLayout, and added a BookingSize enum to determine the size of the booking card and adjusted text and spacing in response. 

## Key checks:

- [x] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [x] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [x] Big iPhone (iPhone 17 Pro Max)
- [x] Small iPhone (iPhone SE)

## Screenshot / Recording

### Before Fixing
<img width="500" alt="Before" src="https://github.com/user-attachments/assets/8237e4af-6c8e-453a-a30f-74633219e5a0" />

### After Fixing
<img width="500" alt="After" src="https://github.com/user-attachments/assets/13a34b54-98b7-41e3-ab23-606d0b4e1a58" />