### PR TITLE
fix: swiping on text in the sheet now registers

### DIFF
--- a/ios/Buildings/Sources/BuildingViews/MapViews/SheetBuildingDetails.swift
+++ b/ios/Buildings/Sources/BuildingViews/MapViews/SheetBuildingDetails.swift
@@ -30,10 +30,12 @@ public struct SheetBuildingDetails: View {
         Text(viewModel.selectedBuildingName)
           .font(.title)
           .fontWeight(.regular)
+          .allowsHitTesting(false)
 
         HStack {
           Text("\(viewModel.selectedBuildingAvailableRooms) rooms available")
             .font(.subheadline)
+            .allowsHitTesting(false)
           Circle()
             .fill(viewModel.selectedBuildingAvailabilityColour)
             .frame(width: 12, height: 12)


### PR DESCRIPTION
## What

Disabled hit testing modifier on sheet title and subtitle, so now tapping on those views no longer do anything.

## Why

When swiping on the sheet, if you were to swipe on the text it wouldn't register to the sheet, disabling hit testing makes them pass through to the sheet now.

## How

Added allowHitTesting(false) view modifier.

## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [x] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [ ] Big iPhone (iPhone 17 Pro Max)
- [ ] Small iPhone (iPhone SE)

## Screenshot / Recording

N/A
