### PR TITLE
fix: fix hooks for format and linting

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,10 +5,12 @@ TOP_LEVEL=$(git rev-parse --show-toplevel)
 if command -v swiftformat >/dev/null 2>&1
 then
     echo "Checking formatting..."
+    DIFF_BEFORE=$(git diff)
     (cd "$TOP_LEVEL" && swiftformat .)
+    DIFF_AFTER=$(git diff)
     
     # check if swiftformat changed any files
-    if ! git diff --exit-code >/dev/null 2>&1
+    if [ "$DIFF_BEFORE" != "$DIFF_AFTER" ]
     then
         echo "Error: Files were modified by the formatter."
         echo "stage the changes and try again."
@@ -22,7 +24,7 @@ fi
 if command -v swiftlint >/dev/null 2>&1
 then
     echo "Running SwiftLint..."
-    (cd "$TOP_LEVEL" && swiftlint)
+    (cd "$TOP_LEVEL" && swiftlint --config ios/.swiftlint.yml)
     # the script will exit here if swiftlint fails
 else
     echo "Warning: swiftlint not found."

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,10 +5,12 @@ TOP_LEVEL=$(git rev-parse --show-toplevel)
 if command -v swiftformat >/dev/null 2>&1
 then
     echo "Checking formatting..."
+    DIFF_BEFORE=$(git diff)
     (cd "$TOP_LEVEL" && swiftformat .)
+    DIFF_AFTER=$(git diff)
     
     # check if swiftformat changed any files
-    if ! git diff --exit-code >/dev/null 2>&1
+    if [ "$DIFF_BEFORE" != "$DIFF_AFTER" ]
     then
         echo "Error: Files were modified by the formatter."
         echo "stage the changes and try again."
@@ -22,7 +24,7 @@ fi
 if command -v swiftlint >/dev/null 2>&1
 then
     echo "Running SwiftLint..."
-    (cd "$TOP_LEVEL" && swiftlint)
+    (cd "$TOP_LEVEL" && swiftlint --config ios/.swiftlint.yml)
     # the script will exit here if swiftlint fails
 else
     echo "Warning: swiftlint not found."


### PR DESCRIPTION
## What

Added better diff check for swift format
Added config path for swift lint

## Why

swift lint would lint files that werent part of the project e.g visor
swift format would always check that your git had no changes even if it wasnt from swift format

## How

Checked git diff before and after running swift format and adding path to config to swift format

## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [ ] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [ ] Big iPhone (iPhone 17 Pro Max)
- [ ] Small iPhone (iPhone SE)

## Screenshot / Recording

N/A
