### PR TITLE
feat: add filter for shortened room name

### DIFF
--- a/ios/Rooms/Sources/RoomInteractors/RoomInteractor.swift
+++ b/ios/Rooms/Sources/RoomInteractors/RoomInteractor.swift
@@ -29,7 +29,10 @@ public class RoomInteractor {
   public func filterRoomsByQueryString(_ rooms: [Room], by searchText: String) -> [Room] {
     guard !searchText.isEmpty else { return rooms }
     let loweredQuery = searchText.lowercased()
-    return rooms.filter { $0.name.lowercased().contains(loweredQuery) }
+    return rooms.filter {
+      $0.name.lowercased().contains(loweredQuery) ||
+        $0.abbreviation.lowercased().contains(loweredQuery)
+    }
   }
 
   public func getRoomsSortedAlphabetically(inAscendingOrder: Bool) async -> Result<[Room], FetchRoomError> {


### PR DESCRIPTION
## What

Add a new filter for students to search room from shortened form.

## Why

Students had to fill in the full room name to be able to search for their rooms.

## How

Add an additional filter for the shortened room name in the return in the RoomInteractor file.

## Key checks:

- [X] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [X] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [X] Big iPhone (iPhone 17 Pro Max)
- [ ] Small iPhone (iPhone SE)

## Screenshot / Recording

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-05 at 17 48 56" src="https://github.com/user-attachments/assets/843d9ffb-a3b3-4069-9aa3-98c7ac5d329e" />

