### PR TITLE
fix: Cache expiry is now properly calculated

### DIFF
--- a/ios/Buildings/Sources/BuildingServices/BuildingLoader.swift
+++ b/ios/Buildings/Sources/BuildingServices/BuildingLoader.swift
@@ -61,12 +61,12 @@ nonisolated public final class LiveGraphQLBuildingLoader: BuildingLoader, Sendab
 
     // Check if we can use the cache
     // TODO: Allow configuration of this value
-    let oldestAllowedCache = Date() - (60 * 60 * 24)
+    let oldestAllowedCache = Date() + (60 * 60 * 24)
     let lastUpdated: Date?
     var buildings: [Building]
     do {
       lastUpdated = try await buildingsCache.lastUpdated
-      if let lastUpdated, lastUpdated > oldestAllowedCache {
+      if let lastUpdated, lastUpdated < oldestAllowedCache {
         logger.trace("Fetching buildings from cache...")
         guard let cacheBuildings = try await buildingsCache.getBuildings() else {
           logger.debug("No buildings in cache, falling back to slowpath")


### PR DESCRIPTION
## What

Changed how cache expiry was calculated

## Why

Cache expiry was not calculated properly

## How

Change how cache expiry was calculating, adding the timeout instead of subtracting.

## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [x] Code comments where needed
- [x] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [x] Big iPhone (iPhone 17 Pro Max)
- [x] Small iPhone (iPhone SE)

## Screenshot / Recording

N/A
