### PR TITLE
feat: optimised ci build time by ensuring it rebuilds when there's change in the build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,8 @@ jobs:
           WORKING_DIRECTORY: ios
         with:
           args: --strict --config .swiftlint.yml
-  tests:
-    name: Tests
-    needs: ["build"]
+  ios-tests:
+    name: iOS Tests
     runs-on: macos-26
     timeout-minutes: 20
     steps:
@@ -58,6 +57,8 @@ jobs:
           swiftpm-package-resolved-file: |
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+      - name: Build for testing
+        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
       - name: Wait for simulator boot
         run: xcrun simctl bootstatus "iPhone 17" -b
       - name: Run tests
@@ -73,25 +74,3 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 17' \
             -parallel-testing-enabled YES \
             -parallel-testing-worker-count 3
-  build:
-    name: Build
-    runs-on: macos-26
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Cache Xcode build data
-        uses: irgaly/xcode-cache@v1
-        with:
-          key: xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
-          restore-keys: |
-            xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-
-          deriveddata-directory: ios/DerivedData
-          swiftpm-package-resolved-file: |
-            ios/**/Package.resolved
-          swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
-
-      - name: Build swift project
-        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Start simulator boot
+        run: xcrun simctl boot "iPhone 17" || true
       - name: Cache Xcode build data
         uses: irgaly/xcode-cache@v1
         with:
@@ -56,8 +58,21 @@ jobs:
           swiftpm-package-resolved-file: |
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+      - name: Wait for simulator boot
+        run: xcrun simctl bootstatus "iPhone 17" -b
       - name: Run tests
-        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3"
+        run: |
+          XCTESTRUN_FILE="$(find DerivedData -name '*.xctestrun' -print -quit)"
+          if [ -z "$XCTESTRUN_FILE" ]; then
+            echo "No .xctestrun file found in DerivedData"
+            exit 1
+          fi
+          echo "Using .xctestrun file: $XCTESTRUN_FILE"
+          xcodebuild test-without-building \
+            -xctestrun "$XCTESTRUN_FILE" \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
+            -parallel-testing-enabled YES \
+            -parallel-testing-worker-count 3
   build:
     name: Build
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
       - name: Run tests
-        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
+        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3"
   build:
     name: Build
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Start simulator boot
         run: xcrun simctl boot "iPhone 17" || true
-      - name: Cache Xcode build data
-        uses: irgaly/xcode-cache@v1
-        with:
-          key: xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
-          restore-keys: |
-            xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-
-          deriveddata-directory: ios/DerivedData
-          swiftpm-package-resolved-file: |
-            ios/**/Package.resolved
-          swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
       - name: Build for testing
         run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
       - name: Wait for simulator boot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
@@ -24,34 +24,59 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: Run formatter check
-      run: swiftformat --lint .
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Run formatter check
+        run: swiftformat --lint .
   lint:
     name: Lint
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: GitHub Action for SwiftLint
-      uses: norio-nomura/action-swiftlint@9f4dcd7fd46b4e75d7935cf2f4df406d5cae3684
-      env:
-        WORKING_DIRECTORY: ios
-      with:
-        args: --strict --config .swiftlint.yml
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: GitHub Action for SwiftLint
+        uses: norio-nomura/action-swiftlint@9f4dcd7fd46b4e75d7935cf2f4df406d5cae3684
+        env:
+          WORKING_DIRECTORY: ios
+        with:
+          args: --strict --config .swiftlint.yml
   tests:
     name: Tests
+    needs: ["build"]
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: Run tests
-      run: "xcodebuild test -skipMacroValidation -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17'"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Cache Xcode build data
+        uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-
+          deriveddata-directory: ios/DerivedData
+          swiftpm-package-resolved-file: |
+            ios/**/Package.resolved
+          swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+      - name: Run tests
+        run: "xcodebuild test-without-building -skipMacroValidation -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
   build:
     name: Build
     runs-on: macos-26
-    timeout-minutes: 5
+    timeout-minutes: 20
+
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: Build swift project
-      run: "xcodebuild build -skipMacroValidation -scheme Freerooms -destination 'platform=iOS Simulator,name=iPhone 17'"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Cache Xcode build data
+        uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-
+          deriveddata-directory: ios/DerivedData
+          swiftpm-package-resolved-file: |
+            ios/**/Package.resolved
+          swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+
+      - name: Build swift project
+        run: "xcodebuild build-for-testing -skipMacroValidation -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,28 +39,44 @@ jobs:
           WORKING_DIRECTORY: ios
         with:
           args: --strict --config .swiftlint.yml
-  ios-tests:
-    name: iOS Tests
+  tests:
+    name: Tests
+    needs: ["build"]
     runs-on: macos-26
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Start simulator boot
-        run: xcrun simctl boot "iPhone 17" || true
+      - name: Cache Xcode build data
+        uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-
+          deriveddata-directory: ios/DerivedData
+          swiftpm-package-resolved-file: |
+            ios/**/Package.resolved
+          swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+      - name: Run tests
+        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3"
+  build:
+    name: Build
+    runs-on: macos-26
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Cache Xcode build data
+        uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            xcode-deriveddata-${{ runner.os }}-${{ github.workflow }}-
+          deriveddata-directory: ios/DerivedData
+          swiftpm-package-resolved-file: |
+            ios/**/Package.resolved
+          swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+
       - name: Build for testing
         run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
-      - name: Wait for simulator boot
-        run: xcrun simctl bootstatus "iPhone 17" -b
-      - name: Run tests
-        run: |
-          XCTESTRUN_FILE="$(find DerivedData -name '*.xctestrun' -print -quit)"
-          if [ -z "$XCTESTRUN_FILE" ]; then
-            echo "No .xctestrun file found in DerivedData"
-            exit 1
-          fi
-          echo "Using .xctestrun file: $XCTESTRUN_FILE"
-          xcodebuild test-without-building \
-            -xctestrun "$XCTESTRUN_FILE" \
-            -destination 'platform=iOS Simulator,name=iPhone 17' \
-            -parallel-testing-enabled YES \
-            -parallel-testing-worker-count 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,20 @@ jobs:
         with:
           args: --strict --config .swiftlint.yml
   tests:
-    name: Tests
+    name: Tests (${{ matrix.name }})
     needs: ["build"]
     runs-on: macos-26
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Rooms
+            only_testing: "-only-testing:RoomsTests"
+          - name: Buildings
+            only_testing: "-only-testing:BuildingsTests"
+          - name: Other
+            only_testing: "-only-testing:NetworkingTests -only-testing:PersistenceTests -only-testing:LocationTests -only-testing:TestingSupportTests"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Cache Xcode build data
@@ -57,7 +67,7 @@ jobs:
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
       - name: Run tests
-        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3"
+        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3 ${{ matrix.only_testing }}"
   build:
     name: Build
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
       - name: Run tests
-        run: "xcodebuild test-without-building -skipMacroValidation -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
+        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
   build:
     name: Build
     runs-on: macos-26
@@ -79,4 +79,4 @@ jobs:
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
 
       - name: Build swift project
-        run: "xcodebuild build-for-testing -skipMacroValidation -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
+        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,37 +40,12 @@ jobs:
         with:
           args: --strict --config .swiftlint.yml
   tests:
-    name: Tests (${{ matrix.name }})
+    name: Tests
     needs: ["build"]
     runs-on: macos-26
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Rooms
-            only_testing: "-only-testing:RoomsTests"
-          - name: Buildings
-            only_testing: "-only-testing:BuildingsTests"
-          - name: Other
-            only_testing: "-only-testing:NetworkingTests -only-testing:PersistenceTests -only-testing:LocationTests -only-testing:TestingSupportTests"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Select simulator
-        id: simulator
-        run: |
-          SIMULATOR_NAME="iPhone 17"
-          SIMULATOR_UDID="$(xcrun simctl list devices available | sed -nE "s/.*${SIMULATOR_NAME} \(([0-9A-F-]{36})\).*/\1/p" | head -n 1)"
-
-          if [ -z "$SIMULATOR_UDID" ]; then
-            DEVICE_TYPE="$(xcrun simctl list devicetypes | sed -nE "s/.*${SIMULATOR_NAME} \((com\.apple\.CoreSimulator\.SimDeviceType\.[^)]+)\).*/\1/p" | head -n 1)"
-            RUNTIME="$(xcrun simctl list runtimes available | sed -nE 's/.* - (com\.apple\.CoreSimulator\.SimRuntime\.iOS-[^ ]+).*/\1/p' | tail -n 1)"
-            SIMULATOR_UDID="$(xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_TYPE" "$RUNTIME")"
-          fi
-
-          xcrun simctl boot "$SIMULATOR_UDID" || true
-          echo "udid=$SIMULATOR_UDID" >> "$GITHUB_OUTPUT"
-          echo "destination=platform=iOS Simulator,id=$SIMULATOR_UDID" >> "$GITHUB_OUTPUT"
       - name: Cache Xcode build data
         uses: irgaly/xcode-cache@v1
         with:
@@ -81,10 +56,8 @@ jobs:
           swiftpm-package-resolved-file: |
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
-      - name: Wait for simulator boot
-        run: xcrun simctl bootstatus "${{ steps.simulator.outputs.udid }}" -b
       - name: Run tests
-        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination '${{ steps.simulator.outputs.destination }}' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3 ${{ matrix.only_testing }}"
+        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3"
   build:
     name: Build
     runs-on: macos-26
@@ -106,4 +79,4 @@ jobs:
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
 
       - name: Build for testing
-        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'generic/platform=iOS Simulator' -derivedDataPath DerivedData"
+        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
             only_testing: "-only-testing:NetworkingTests -only-testing:PersistenceTests -only-testing:LocationTests -only-testing:TestingSupportTests"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Select simulator
+        id: simulator
+        run: |
+          SIMULATOR_NAME="iPhone 17"
+          SIMULATOR_UDID="$(xcrun simctl list devices available | sed -nE "s/.*${SIMULATOR_NAME} \(([0-9A-F-]{36})\).*/\1/p" | head -n 1)"
+
+          if [ -z "$SIMULATOR_UDID" ]; then
+            DEVICE_TYPE="$(xcrun simctl list devicetypes | sed -nE "s/.*${SIMULATOR_NAME} \((com\.apple\.CoreSimulator\.SimDeviceType\.[^)]+)\).*/\1/p" | head -n 1)"
+            RUNTIME="$(xcrun simctl list runtimes available | sed -nE 's/.* - (com\.apple\.CoreSimulator\.SimRuntime\.iOS-[^ ]+).*/\1/p' | tail -n 1)"
+            SIMULATOR_UDID="$(xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_TYPE" "$RUNTIME")"
+          fi
+
+          xcrun simctl boot "$SIMULATOR_UDID" || true
+          echo "udid=$SIMULATOR_UDID" >> "$GITHUB_OUTPUT"
+          echo "destination=platform=iOS Simulator,id=$SIMULATOR_UDID" >> "$GITHUB_OUTPUT"
       - name: Cache Xcode build data
         uses: irgaly/xcode-cache@v1
         with:
@@ -66,8 +81,10 @@ jobs:
           swiftpm-package-resolved-file: |
             ios/**/Package.resolved
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
+      - name: Wait for simulator boot
+        run: xcrun simctl bootstatus "${{ steps.simulator.outputs.udid }}" -b
       - name: Run tests
-        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3 ${{ matrix.only_testing }}"
+        run: "xcodebuild test-without-building -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination '${{ steps.simulator.outputs.destination }}' -derivedDataPath DerivedData -parallel-testing-enabled YES -parallel-testing-worker-count 3 ${{ matrix.only_testing }}"
   build:
     name: Build
     runs-on: macos-26
@@ -89,4 +106,4 @@ jobs:
           swiftpm-cache-key: xcode-sourcepackages-${{ runner.os }}-${{ hashFiles('ios/**/Package.resolved') }}
 
       - name: Build for testing
-        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath DerivedData"
+        run: "xcodebuild build-for-testing -skipMacroValidation -workspace FreeroomsApple.xcworkspace -scheme Tests -destination 'generic/platform=iOS Simulator' -derivedDataPath DerivedData"


### PR DESCRIPTION
## What

- Ensured Tests wait for Build 
- Ensured that Tests and Build share the same Xcode cache key so the Tests job can restore that job's cache.
- Use the same DerivedData location so both jobs cache the same known folder.
- Made only the Build job to compile the test artifacts once.
- The Tests job waits for build, restores cached DerivedData, then runs Tests job without rebuilding.

## Why

- Cache build so it only rebuilds packages that change.
- The test pipeline should reuse the files from the build step during the pipeline. currently it builds it again during test step

## How

- Added a new field `needs: ["build"]` for Tests job.
- Copied code from [Xcode Cache](https://github.com/marketplace/actions/xcode-cache) to setup the Xcode cache for both Tests and Build job
- Ensured the Build job compile the test scheme artifact once instead of having both Build and Tests compiling it. 
- Since Build job would be building the artifact, the timeout-minutes was adjusted to 20.

## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [ ] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [ ] Big iPhone (iPhone 17 Pro Max)
- [ ] Small iPhone (iPhone SE)

## Screenshot / Recording

N/A
