### PR TITLE
feat: add availability status in room details sheet

### DIFF
--- a/ios/Rooms/Sources/RoomViews/RatingViews/RoomBookingInformationView.swift
+++ b/ios/Rooms/Sources/RoomViews/RatingViews/RoomBookingInformationView.swift
@@ -61,18 +61,21 @@ struct RoomBookingInformationView: View {
       }
 
       VStack(alignment: .leading, spacing: 10) {
-        if room.school.trimmingCharacters(in: .whitespaces) == "" {
-          EmptyView()
-        } else {
-          Text("School of \(room.school)")
+        HStack {
+          Text("\(room.abbreviation)")
             .font(.title3)
             .bold()
             .foregroundStyle(.primary)
+          Spacer()
+          Text("\(room.statusText)")
+            .font(.system(size: 20, weight: .light))
+            .foregroundStyle(room.statusTextColour)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(
+              RoundedRectangle(cornerRadius: 5)
+                .fill(room.statusBackgroundColor))
         }
-        Text("\(room.abbreviation)")
-          .font(.callout)
-          .foregroundStyle(.primary)
-          .bold()
       }
       .frame(maxWidth: .infinity, alignment: .leading)
       .padding(.vertical, 12)


### PR DESCRIPTION
## What

Show availability status in room details sheet.

## Why

User can see when the room is available until or whether the room is unavailable without scrolling down to the sheet.

## How

Add availability status text

## Key checks:

- [x] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [x] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [x] Big iPhone (iPhone 17 Pro Max)
- [x] Small iPhone (iPhone SE)

## Screenshot / Recording

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/d1a84cc5-d582-4a26-88d8-30ec3423602b" />

<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/271acf46-8de9-4a00-90a1-b2511a39b369" />
