### PR TITLE
Bug: Map room sheet loading slow and cannot be dismissed

### DIFF
--- a/ios/Buildings/Sources/BuildingViews/BuildingsTabView.swift
+++ b/ios/Buildings/Sources/BuildingViews/BuildingsTabView.swift
@@ -215,7 +215,7 @@ public struct BuildingsTabView<BuildingDestination: View, RoomDestination: View>
 
 // MARK: - PreviewWrapper
 
-struct PreviewWrapper: View {
+private struct PreviewWrapper: View {
   @State var path = NavigationPath()
   @State var selectedView = ViewOrientation.List
 

--- a/ios/Buildings/Sources/BuildingViews/MapViews/MapTabView.swift
+++ b/ios/Buildings/Sources/BuildingViews/MapViews/MapTabView.swift
@@ -17,7 +17,9 @@ extension View {
   func hideKeyboard() {
     UIApplication.shared.sendAction(
       #selector(UIResponder.resignFirstResponder),
-      to: nil, from: nil, for: nil)
+      to: nil,
+      from: nil,
+      for: nil)
   }
 }
 
@@ -28,6 +30,7 @@ public struct MapTabView<RoomDestination: View>: View {
   // MARK: Lifecycle
 
   public init(
+    path: Binding<NavigationPath>,
     mapViewModel: LiveMapViewModel,
     roomImageProvider: @escaping (String) -> CachedImage,
     roomDestinationBuilder: @escaping (Room) -> RoomDestination)
@@ -35,110 +38,125 @@ public struct MapTabView<RoomDestination: View>: View {
     self.mapViewModel = mapViewModel
     self.roomImageProvider = roomImageProvider
     self.roomDestinationBuilder = roomDestinationBuilder
+    _path = path
   }
 
   // MARK: Public
 
   public var body: some View {
-    ZStack {
-      Map(position: $mapViewModel.position, bounds: mapViewModel.mapCameraBounds) {
-        UserAnnotation {
-          ZStack {
-            CompassUserAnnotation()
-              .environment(mapViewModel)
+    NavigationStack(path: $path) {
+      ZStack {
+        Map(
+          position: $mapViewModel.position,
+          bounds: mapViewModel.mapCameraBounds)
+        {
+          UserAnnotation {
+            ZStack {
+              CompassUserAnnotation()
+                .environment(mapViewModel)
+            }
+          }
+
+          if let route = mapViewModel.currentRoute {
+            let coordinates = route.polyline.coordinates
+            MapPolyline(coordinates: coordinates)
+              .stroke(
+                .orange,
+                style: StrokeStyle(
+                  lineWidth: 5))
+          }
+
+          ForEach(mapViewModel.buildings, id: \.id) { building in
+            Annotation(building.name, coordinate: building.coordinate) {
+              BuildingAnnotationView(
+                building: building,
+                isSelected: mapViewModel.isSelectedBuilding(building.id))
+                .onTapGesture {
+                  Task {
+                    await mapViewModel.onSelectBuilding(building.id)
+                  }
+                }
+            }
           }
         }
-
-        if let route = mapViewModel.currentRoute {
-          let coordinates = route.polyline.coordinates
-          MapPolyline(coordinates: coordinates)
-            .stroke(
-              .orange,
-              style: StrokeStyle(
-                lineWidth: 5))
+        .onChange(of: mapViewModel.selectedBuildingID) { _, _ in }
+        .onMapCameraChange { context in
+          mapViewModel.updateMapHeading(context.camera.heading)
         }
-
-        ForEach(mapViewModel.buildings, id: \.id) { building in
-          Annotation(building.name, coordinate: building.coordinate) {
-            BuildingAnnotationView(
-              building: building,
-              isSelected: mapViewModel.isSelectedBuilding(building.id))
-              .onTapGesture {
-                Task {
-                  await mapViewModel.onSelectBuilding(building.id)
+        .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
+        .mapControls { }
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              if
+                mapViewModel.bottomSheetPosition
+                == SheetPosition.top.bottomSheetPosition
+              {
+                withAnimation(.spring()) {
+                  mapViewModel.bottomSheetPosition =
+                    SheetPosition.medium.bottomSheetPosition
                 }
               }
-          }
+            })
+        .task {
+          mapViewModel.requestLocationPermission()
+          await mapViewModel.loadBuildings()
         }
-      }
-      .onChange(of: mapViewModel.selectedBuildingID) { _, _ in }
-      .onMapCameraChange { context in
-        mapViewModel.updateMapHeading(context.camera.heading)
-      }
-      .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
-      .mapControls { }
-      .simultaneousGesture(
-        TapGesture()
-          .onEnded {
-            if mapViewModel.bottomSheetPosition == SheetPosition.top.bottomSheetPosition {
-              withAnimation(.spring()) {
-                mapViewModel.bottomSheetPosition = SheetPosition.medium.bottomSheetPosition
-              }
-            }
-          })
-      .task {
-        mapViewModel.requestLocationPermission()
-        await mapViewModel.loadBuildings()
-      }
-      .zIndex(0)
+        .zIndex(0)
 
-      VStack(spacing: 0) {
-        MapSearchBar(searchtxt: $mapViewModel.searchText)
-          .padding(.bottom, 6)
-        if !mapViewModel.searchText.isEmpty {
-          MapSearchBarList()
+        VStack(spacing: 0) {
+          MapSearchBar(searchtxt: $mapViewModel.searchText)
+            .padding(.bottom, 6)
+          if !mapViewModel.searchText.isEmpty {
+            MapSearchBarList()
+          }
+          Spacer()
         }
-        Spacer()
+        .opacity(
+          mapViewModel.bottomSheetPosition
+            == SheetPosition.top.bottomSheetPosition ? 0 : 1)
+        .animation(
+          .easeInOut(duration: 0.3),
+          value: mapViewModel.bottomSheetPosition)
       }
-      .opacity(mapViewModel.bottomSheetPosition == SheetPosition.top.bottomSheetPosition ? 0 : 1)
-      .animation(.easeInOut(duration: 0.3), value: mapViewModel.bottomSheetPosition)
-    }
-    .bottomSheet(
-      bottomSheetPosition: $mapViewModel.bottomSheetPosition,
-      switchablePositions: [
-        SheetPosition.top.bottomSheetPosition,
-        SheetPosition.medium.bottomSheetPosition,
-        SheetPosition.short.bottomSheetPosition,
-      ]) {
-        VStack {
-          if mapViewModel.bottomSheetPosition == SheetPosition.short.bottomSheetPosition {
-            SheetDirectionDetails()
-          } else {
-            SheetBuildingDetails(
-              imageProvider: roomImageProvider,
-              onSelectRoom: { room in
-                selectedRoom = room
-              })
+      .bottomSheet(
+        bottomSheetPosition: $mapViewModel.bottomSheetPosition,
+        switchablePositions: [
+          SheetPosition.top.bottomSheetPosition,
+          SheetPosition.medium.bottomSheetPosition,
+          SheetPosition.short.bottomSheetPosition,
+        ]) {
+          VStack {
+            if
+              mapViewModel.bottomSheetPosition
+              == SheetPosition.short.bottomSheetPosition
+            {
+              SheetDirectionDetails()
+            } else {
+              SheetBuildingDetails(
+                imageProvider: roomImageProvider,
+                onSelectRoom: { room in
+                  path.append(room)
+                })
+            }
+          }
+      }
+      .customBackground(
+        Color(uiColor: .systemBackground)
+          .cornerRadius(20)
+          .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: -5))
+      .onChange(of: mapViewModel.bottomSheetPosition) { _, newValue in
+        if newValue == SheetPosition.medium.bottomSheetPosition {
+          mapViewModel.clearDirection()
+        } else if newValue == SheetPosition.short.bottomSheetPosition {
+          Task {
+            await mapViewModel.getDirectionToSelectedBuilding()
           }
         }
-    }
-    .customBackground(
-      Color(uiColor: .systemBackground)
-        .cornerRadius(20)
-        .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: -5))
-    .onChange(of: mapViewModel.bottomSheetPosition) { _, newValue in
-      if newValue == SheetPosition.medium.bottomSheetPosition {
-        mapViewModel.clearDirection()
-      } else if newValue == SheetPosition.short.bottomSheetPosition {
-        Task {
-          await mapViewModel.getDirectionToSelectedBuilding()
-        }
       }
-    }
-    .environment(mapViewModel)
-    .ignoresSafeArea(.keyboard)
-    .fullScreenCover(item: $selectedRoom) { room in
-      NavigationStack {
+      .environment(mapViewModel)
+      .ignoresSafeArea(.keyboard)
+      .navigationDestination(for: Room.self) { room in
         roomDestinationBuilder(room)
       }
     }
@@ -151,25 +169,33 @@ public struct MapTabView<RoomDestination: View>: View {
   // MARK: Internal
 
   @Bindable var mapViewModel: LiveMapViewModel
+  @Binding var path: NavigationPath
 
   let roomImageProvider: (String) -> CachedImage
   let roomDestinationBuilder: (Room) -> RoomDestination
 
-  // MARK: Private
+}
 
-  @State private var selectedRoom: Room?
+// MARK: - PreviewWrapper
 
+private struct PreviewWrapper: View {
+  @State var path = NavigationPath()
+
+  var body: some View {
+    MapTabView(
+      path: $path,
+      mapViewModel: PreviewMapViewModel(),
+      roomImageProvider: { roomID in
+        CachedImage(name: roomID, bundle: .module)
+      },
+      roomDestinationBuilder: { _ in
+        EmptyView()
+      })
+  }
 }
 
 // MARK: - Preview
 
 #Preview {
-  MapTabView(
-    mapViewModel: PreviewMapViewModel(),
-    roomImageProvider: { roomID in
-      CachedImage(name: roomID, bundle: .module)
-    },
-    roomDestinationBuilder: { _ in
-      EmptyView()
-    })
+  PreviewWrapper()
 }

--- a/ios/Freerooms/Freerooms/ContentView.swift
+++ b/ios/Freerooms/Freerooms/ContentView.swift
@@ -46,6 +46,7 @@ struct ContentView: View {
           }
       }
       MapTabView(
+        path: $mapPath,
         mapViewModel: mapViewModel,
         roomImageProvider: { roomID in
           RoomImage[roomID]
@@ -79,6 +80,7 @@ struct ContentView: View {
   // MARK: Private
 
   @State private var buildingPath = NavigationPath()
+  @State private var mapPath = NavigationPath()
   @State private var roomPath = NavigationPath()
 
   @Environment(Theme.self) private var theme


### PR DESCRIPTION
## What

When viewing rooms from the Map tab, room views load slowly and cannot be dismissed by swiping left. 

## How

Currently, a new NavigationStack is created every time a room is access from the Map tab, which makes loading slow. Instead, a NavigationPath for the Map tab is passed down from ContentView to the Map tab, so rooms can be appended to the path, fixing the loading and dismissing issue.

## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [x] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [ ] Big iPhone (iPhone 17 Pro Max)
- [x] Small iPhone (iPhone SE)

## Screenshot / Recording