### PR TITLE
chore: hid the navbar in map tab

### DIFF
--- a/ios/Buildings/Sources/BuildingViews/MapViews/MapTabView.swift
+++ b/ios/Buildings/Sources/BuildingViews/MapViews/MapTabView.swift
@@ -79,6 +79,7 @@ public struct MapTabView<RoomDestination: View>: View {
             }
           }
         }
+        .toolbar(.hidden, for: .navigationBar)
         .onChange(of: mapViewModel.selectedBuildingID) { _, _ in }
         .onMapCameraChange { context in
           mapViewModel.updateMapHeading(context.camera.heading)


### PR DESCRIPTION
## What

hid the navbar in map tab

## Why

The navbar adds unnecessary padding to the search bar

## How

```swift
.toolbar(.hidden, for: .navigationBar)
```
## Key checks:

- [ ] 🚩**Attached screenshot or recording of the changes in related tickets**
- [ ] Code comments where needed
- [ ] No new warnings

## Automated tests:

- [ ] 🚩**Unit tests added**

## Manual tests:

- [ ] Big iPhone (iPhone 17 Pro Max)
- [ ] Small iPhone (iPhone SE)

## Screenshot / Recording

N/A
